### PR TITLE
Fixing bug in reads_trimer.py that leads to no barcodes_1.txt file being written

### DIFF
--- a/tnseeker/reads_trimer.py
+++ b/tnseeker/reads_trimer.py
@@ -209,7 +209,7 @@ def extractor(fastq,folder_path,sequences,barcode,barcode_upstream,barcode_downs
         write(trimmed, "/processed_reads_1.fastq", folder_path)
     else:
         trimmed,barcodes=read_trimer(read_bucket,transposon_seq,quality_set,mismatches,trimming_len,miss_up,miss_down,
-                                     quality_set_bar_up,quality_set_bar_down,borders=borders)
+                                     quality_set_bar_up,quality_set_bar_down,borders, True)
         write(trimmed, "/processed_reads_1.fastq", folder_path)
         write(barcodes, "/barcodes_1.txt", folder_path)
     count_trimed+=len(trimmed)


### PR DESCRIPTION
Hi Afonso,

while trying to get tnseeker to run I found a bug. Without these changes, at least in some cases/some machines, the whole barcode pipeline failed because the intermedaite barcodes_1.txt was never written (essentially because `barcode_allow` was by mistake set to `False` instead of `True` in `read_trimer`.

